### PR TITLE
feat: wizard maker

### DIFF
--- a/packages/cli/src/bridge-wizard/EnterAmount.tsx
+++ b/packages/cli/src/bridge-wizard/EnterAmount.tsx
@@ -37,18 +37,18 @@ const supportedAmounts: bigint[] = [
 ];
 
 export const EnterAmount = () => {
-	const {state, setAmount} = useBridgeWizardStore();
+	const {wizardState, submitEnterAmount} = useBridgeWizardStore();
 
-	if (state.step !== 'enter-amount') {
+	if (wizardState.stepId !== 'enter-amount') {
 		throw new Error('Invalid state');
 	}
 
 	const {data: balance, isLoading: isLoadingBalance} = useBalance(
-		state.network,
-		state.address,
+		wizardState.network,
+		wizardState.address,
 	);
 
-	const numChains = state.chainIds.length;
+	const numChains = wizardState.chainIds.length;
 
 	return (
 		<Box flexDirection="column" gap={1}>
@@ -58,7 +58,7 @@ export const EnterAmount = () => {
 			</Text>
 
 			<Box paddingLeft={2}>
-				<Text dimColor>Balance on {state.network}: </Text>
+				<Text dimColor>Balance on {wizardState.network}: </Text>
 				{isLoadingBalance ? (
 					<Spinner />
 				) : balance ? (
@@ -84,7 +84,9 @@ export const EnterAmount = () => {
 							value: amount.toString(),
 						};
 					})}
-					onChange={amount => setAmount(BigInt(amount))}
+					onChange={amount => {
+						submitEnterAmount({amount: BigInt(amount)});
+					}}
 				/>
 			</Box>
 		</Box>

--- a/packages/cli/src/bridge-wizard/EnterPrivateKey.tsx
+++ b/packages/cli/src/bridge-wizard/EnterPrivateKey.tsx
@@ -6,14 +6,14 @@ import {useState} from 'react';
 import {Account, isHex} from 'viem';
 
 export const EnterPrivateKey = () => {
-	const {state, setPrivateKey} = useBridgeWizardStore();
+	const {wizardState, submitEnterPrivateKey} = useBridgeWizardStore();
+
+	if (wizardState.stepId !== 'enter-private-key') {
+		throw new Error('Invalid state');
+	}
 
 	const [errorMessage, setErrorMessage] = useState<string>('');
 	const [resetKey, setResetKey] = useState(0);
-
-	if (state.step !== 'enter-private-key') {
-		throw new Error('Invalid state');
-	}
 
 	return (
 		<Box flexDirection="column">
@@ -42,7 +42,10 @@ export const EnterPrivateKey = () => {
 						return;
 					}
 
-					setPrivateKey(privateKey, account.address);
+					submitEnterPrivateKey({
+						privateKey,
+						address: account.address,
+					});
 				}}
 			/>
 			{errorMessage && (

--- a/packages/cli/src/bridge-wizard/SelectNetwork.tsx
+++ b/packages/cli/src/bridge-wizard/SelectNetwork.tsx
@@ -1,14 +1,14 @@
-import {SupportedNetwork} from '@/utils/superchainRegistry';
 import {useBridgeWizardStore} from '@/bridge-wizard/bridgeWizardStore';
+import {SupportedNetwork} from '@/utils/superchainRegistry';
 import {Select} from '@inkjs/ui';
 import {Box, Text} from 'ink';
 
 const supportedNetworks: SupportedNetwork[] = ['mainnet', 'sepolia'];
 
 export const SelectNetwork = () => {
-	const {state, selectNetwork} = useBridgeWizardStore();
+	const {wizardState, submitSelectNetwork} = useBridgeWizardStore();
 
-	if (state.step !== 'select-network') {
+	if (wizardState.stepId !== 'select-network') {
 		throw new Error('Invalid state');
 	}
 
@@ -20,7 +20,7 @@ export const SelectNetwork = () => {
 					label: network,
 					value: network,
 				}))}
-				onChange={selectNetwork}
+				onChange={value => submitSelectNetwork({network: value})}
 			/>
 		</Box>
 	);

--- a/packages/cli/src/wizard-builder/createWizardStore.ts
+++ b/packages/cli/src/wizard-builder/createWizardStore.ts
@@ -1,0 +1,85 @@
+import {
+	InferFieldsAtStep,
+	InferStateAtStep,
+	WizardStep,
+} from '@/wizard-builder/defineWizard';
+import {
+	capitalizeWords,
+	CapitalizeWords,
+	Prettify,
+} from '@/wizard-builder/utils';
+import {create} from 'zustand';
+
+export type WizardPossibleStates<Steps extends WizardStep<any, any>[]> = {
+	[Index in keyof Steps]: Prettify<
+		{
+			readonly stepId: Steps[Index]['id'];
+		} & InferStateAtStep<Steps, Steps[Index]['id']>
+	>;
+}[number];
+
+export type DefineStoreType<Steps extends WizardStep<any, any, string>[]> = {
+	wizardState: WizardPossibleStates<Steps>;
+	steps: Steps;
+} & {
+	[Step in Steps[number] as `submit${CapitalizeWords<Step['id']>}`]: (
+		value: InferFieldsAtStep<Steps, Step['id']>,
+	) => void;
+};
+
+// Factory function to create the store
+export function createWizardStore<Steps extends WizardStep<any, any, any>[]>(
+	wizard: Steps,
+) {
+	type WizardType = Steps;
+	type PossibleStates = WizardPossibleStates<WizardType>;
+
+	type StoreType = DefineStoreType<Steps>;
+
+	const initialState: PossibleStates = {
+		stepId: wizard[0]!.id,
+	} as PossibleStates;
+
+	const store = create<StoreType>((set, get) => {
+		const submitFunctions = wizard.reduce((acc, step, index) => {
+			const currentStepId = step.id;
+			const nextStepId = wizard[index + 1]?.id || 'completed';
+
+			const functionName = `submit${capitalizeWords(
+				currentStepId,
+			)}` as keyof StoreType;
+
+			acc[functionName] = (
+				value: InferFieldsAtStep<WizardType, typeof currentStepId>,
+			) => {
+				const currentState = get().wizardState as Extract<
+					WizardPossibleStates<WizardType>,
+					{stepId: typeof currentStepId}
+				>;
+
+				const nextState: Extract<
+					WizardPossibleStates<WizardType>,
+					{stepId: typeof nextStepId}
+				> = {
+					...currentState,
+					...value,
+					stepId: nextStepId,
+				};
+
+				set({
+					wizardState: nextState,
+				} as StoreType);
+			};
+
+			return acc;
+		}, {} as Record<string, (value: any) => void>);
+
+		return {
+			wizardState: initialState,
+			steps: wizard,
+			...submitFunctions,
+		} as StoreType;
+	});
+
+	return store;
+}

--- a/packages/cli/src/wizard-builder/defineWizard.ts
+++ b/packages/cli/src/wizard-builder/defineWizard.ts
@@ -1,0 +1,113 @@
+import {Prettify} from '@/wizard-builder/utils';
+import {z} from 'zod';
+
+export type WizardStep<
+	State,
+	TSchema extends z.ZodTypeAny,
+	Id extends string = string,
+> = {
+	id: Id;
+	schema: TSchema;
+	getSummary?: (state: State & z.infer<TSchema>) => string;
+	title: string;
+};
+
+type WizardBuilder<State = {}, Steps extends WizardStep<any, any>[] = []> = {
+	addStep: <TSchema extends z.ZodTypeAny, Id extends string>(
+		wizardStep: WizardStep<State, TSchema, Id>,
+	) => WizardBuilder<
+		State & z.infer<TSchema>,
+		[...Steps, WizardStep<State, TSchema, Id>]
+	>;
+	build: () => [
+		...Steps,
+		WizardStep<
+			AccumulateStateFromSteps<Steps>,
+			typeof completedState.schema,
+			'completed'
+		>,
+	];
+};
+
+type AccumulateStateFromSteps<Steps extends WizardStep<any, any>[]> =
+	Steps extends [WizardStep<any, infer TSchema, infer Id>, ...infer Rest]
+		? Id extends 'completed'
+			? {}
+			: z.infer<TSchema> &
+					AccumulateStateFromSteps<
+						Rest extends WizardStep<any, any, any>[] ? Rest : []
+					>
+		: {};
+
+type AccumulateStateBeforeId<
+	Steps extends WizardStep<any, any>[],
+	Id extends string,
+	AccumulatedState = {},
+> = Steps extends [infer First, ...infer Rest]
+	? First extends WizardStep<any, infer TSchema, infer StepId>
+		? StepId extends Id
+			? AccumulatedState
+			: AccumulateStateBeforeId<
+					Rest extends WizardStep<any, any>[] ? Rest : [],
+					Id,
+					AccumulatedState & z.infer<TSchema>
+			  >
+		: never
+	: AccumulatedState;
+
+export type InferStateAtStep<
+	Steps extends WizardStep<any, any>[],
+	StepId extends string,
+> = Prettify<AccumulateStateBeforeId<Steps, StepId>>;
+
+export type InferFieldsAtStep<
+	Steps extends WizardStep<any, any>[],
+	StepId extends string,
+> = Steps extends [infer First, ...infer Rest]
+	? First extends WizardStep<any, infer TSchema, infer Id>
+		? Id extends StepId
+			? z.infer<TSchema>
+			: InferFieldsAtStep<
+					Rest extends WizardStep<any, any>[] ? Rest : [],
+					StepId
+			  >
+		: never
+	: never;
+
+export type InferFinalState<Steps extends WizardStep<any, any>[]> = Prettify<
+	AccumulateStateFromSteps<Steps>
+>;
+
+export type InferStepId<Steps extends WizardStep<any, any>[]> =
+	Steps[number]['id'];
+
+const completedState = {
+	id: 'completed' as const,
+	schema: z.object({}),
+} as const;
+
+export function defineWizard<
+	State = {},
+	Steps extends WizardStep<any, any, any>[] = [],
+>(steps: Steps = [] as unknown as Steps): WizardBuilder<State, Steps> {
+	return {
+		addStep<TSchema extends z.ZodTypeAny, Id extends string>(
+			wizardStep: WizardStep<State, TSchema, Id>,
+		) {
+			return defineWizard<
+				State & z.infer<TSchema>,
+				[...Steps, WizardStep<State, TSchema, Id>]
+			>([...steps, wizardStep] as [...Steps, WizardStep<State, TSchema, Id>]);
+		},
+		build: () => {
+			return [...steps, completedState] as [
+				...Steps,
+				WizardStep<
+					AccumulateStateFromSteps<Steps>,
+					typeof completedState.schema,
+					'completed'
+				>,
+			];
+		},
+	};
+}

--- a/packages/cli/src/wizard-builder/example.ts
+++ b/packages/cli/src/wizard-builder/example.ts
@@ -1,0 +1,38 @@
+import {createWizardStore} from '@/wizard-builder/createWizardStore';
+import {defineWizard} from '@/wizard-builder/defineWizard';
+import {z} from 'zod';
+
+const bridgeWizard = defineWizard()
+	.addStep({
+		id: 'selectNetwork',
+		schema: z.object({
+			network: z.string(),
+		}),
+		title: 'Select Network',
+		getSummary: state => `${state.network}`,
+	})
+	.addStep({
+		id: 'selectChains',
+		schema: z.object({
+			chainIds: z.array(z.number()),
+		}),
+		title: 'Select Chains',
+		getSummary: state => `${state.chainIds.join(', ')}`,
+	})
+	.addStep({
+		id: 'enterAmount',
+		schema: z.object({
+			amount: z.bigint(),
+		}),
+		title: 'Enter Amount',
+		getSummary: state => {
+			return `Amount: ${state.amount}`;
+		},
+	})
+	.build();
+
+type BridgeWizardType = typeof bridgeWizard;
+
+export const store = createWizardStore(bridgeWizard);
+
+const currentState = store.getState();

--- a/packages/cli/src/wizard-builder/utils.ts
+++ b/packages/cli/src/wizard-builder/utils.ts
@@ -1,0 +1,23 @@
+// converts snake case to camel case
+export function capitalizeWords(s: string): string {
+	return s.replace(/(?:^|-)([a-z])/g, (_, c) => c.toUpperCase());
+}
+
+// converts snake case to camel case
+
+export type CapitalizeWords<S extends string> =
+	S extends `${infer First}-${infer Rest}`
+		? `${Capitalize<First>}${CapitalizeWords<Rest>}`
+		: Capitalize<S>;
+
+/**
+ * @description Combines members of an intersection into a readable type.
+ *
+ * @see {@link https://twitter.com/mattpocockuk/status/1622730173446557697?s=20&t=NdpAcmEFXY01xkqU3KO0Mg}
+ * @example
+ * Prettify<{ a: string } & { b: string } & { c: number, d: bigint }>
+ * => { a: string, b: string, c: number, d: bigint }
+ */
+export type Prettify<T> = {
+	[K in keyof T]: T[K];
+} & {};


### PR DESCRIPTION
once it's more mature will move it out to it's own package

typesafe wizard builder - definitely overengineered & still some rough edges but improves devx around building wizards.

1. define a series of wizard steps
2. create zustand store - turns it into discriminated union of states where each step accumulates upon the last one
3. zustand store now automagically includes each of the state transitions possible (ie. submitSelectNetwork - is typesafe)
<img width="670" alt="image" src="https://github.com/user-attachments/assets/8efc2cc1-ced4-4ae3-85e1-c88ebc45ce4b">


ie. 
<img width="307" alt="image" src="https://github.com/user-attachments/assets/af339450-76bd-49fb-8f92-08c176338307">

<img width="670" alt="image" src="https://github.com/user-attachments/assets/88b73a3a-a7b7-438c-92ef-79715b17c939">
