### PR TITLE
Adds support for toml configs

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -31,6 +31,7 @@
 		"ink": "^5.0.1",
 		"pastel": "^3.0.0",
 		"react": "^18.2.0",
+		"smol-toml": "^1.3.1",
 		"viem": "^2.21.41",
 		"zod": "^3.21.4",
 		"zod-validation-error": "^3.4.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -2,7 +2,9 @@
 	"name": "@eth-optimism/super-cli",
 	"version": "0.0.1",
 	"license": "MIT",
-	"bin": "dist/cli.js",
+	"bin": {
+		"super": "dist/cli.js"
+	},
 	"type": "module",
 	"engines": {
 		"node": ">=18.20"

--- a/packages/cli/src/utils/config.ts
+++ b/packages/cli/src/utils/config.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+import { parse as parseTOML } from "smol-toml";
+import fs from "fs";
+
+export const zodSuperConfig = z.object({
+	rpc_endpoints: z.record(z.string(), z.string()).optional(),
+        verification_endpoints: z.record(z.string(), z.string()).optional(),
+        creation_params: z.array(
+                z.object({
+                        salt: z.string(),
+                        chains: z.array(z.string()),
+                        network: z.string(),
+                        verify: z.boolean(),
+                        constructor_args: z.array(z.any()).optional()
+                })
+        ).optional()
+})
+
+export function parseSuperConfigFromTOML(pathToConfig: string) {
+    const toml = fs.readFileSync(pathToConfig, {encoding: 'utf-8'});
+
+    if (!toml) {
+        throw new Error('Config file is empty');
+    }
+
+    const parsed = parseTOML(toml);
+    const config = parsed['supercli'];
+    if (!config) {
+        throw new Error('[supercli] config not found in toml file.');
+    }
+
+    const parsedConfig = zodSuperConfig.safeParse(config);
+    if (parsedConfig.success === false) {
+        throw new Error('Config file is invalid');
+    }
+
+    return parsedConfig.data;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       react:
         specifier: ^18.2.0
         version: 18.3.1
+      smol-toml:
+        specifier: ^1.3.1
+        version: 1.3.1
       viem:
         specifier: ^2.21.41
         version: 2.21.41(typescript@5.6.3)(zod@3.23.8)
@@ -2789,6 +2792,10 @@ packages:
   smart-buffer@4.2.0:
     resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
     engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
+  smol-toml@1.3.1:
+    resolution: {integrity: sha512-tEYNll18pPKHroYSmLLrksq233j021G0giwW7P3D24jC54pQ5W5BXMsQ/Mvw1OJCmEYDgY+lrzT+3nNUtoNfXQ==}
+    engines: {node: '>= 18'}
 
   socks-proxy-agent@8.0.4:
     resolution: {integrity: sha512-GNAq/eg8Udq2x0eNiFkr9gRg5bA7PXEWagQdeRX4cPSG+X/8V38v637gim9bjFptMk1QWsCTr0ttrJEiXbNnRw==}
@@ -5965,6 +5972,8 @@ snapshots:
       is-fullwidth-code-point: 5.0.0
 
   smart-buffer@4.2.0: {}
+
+  smol-toml@1.3.1: {}
 
   socks-proxy-agent@8.0.4:
     dependencies:


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

First pass at getting toml configs working.

* Adds `soml-toml` to parse toml files
* Adds `utils/config.ts` that defines the supercli schema
* Updates the `deploy create2` command to include a `toml` flag and adds support for parsing and normalizing it.

Did not test out the verify flow yet, this PR was tested against our starterkit with the following config
```
[supercli]

[[supercli.creation_params]]
salt = "ethers phoenix"
chains = ["op", "base"]
network = "mainnet"
verify = false
constructor_args = [
  "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
  "TestSuperchainERC20",
  "TSU",
  18
]
```

Command
```
pnpm nx run @eth-optimism/super-cli:dev deploy create2 \    
  --toml ../../../superchainerc20-starter/packages/contracts/foundry.toml \
  --forge-artifact-path ../../../superchainerc20-starter/packages/contracts/out/L2NativeSuperchainERC20.sol//L2NativeSuperchainERC20.json \
  -pk $A0_PK
```