### PR TITLE
Remove Signer FE

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -27,7 +27,6 @@
 		"@hono/node-server": "^1.13.7",
 		"@inkjs/ui": "^2.0.0",
 		"@libsql/client": "^0.14.0",
-		"@super-cli/signer-frontend": "workspace:*",
 		"@tanstack/react-query": "^5.59.20",
 		"@vitejs/plugin-react": "^4.3.3",
 		"abitype": "^1.0.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,9 +33,6 @@ importers:
       '@libsql/client':
         specifier: ^0.14.0
         version: 0.14.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      '@super-cli/signer-frontend':
-        specifier: workspace:*
-        version: link:../signer-frontend
       '@tanstack/react-query':
         specifier: ^5.59.20
         version: 5.59.20(react@18.3.1)


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

Removes the signer FE for the time being so npm installs will start working again.