### PR TITLE
feat: fix package name

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -25,7 +25,6 @@
 		"drizzle"
 	],
 	"dependencies": {
-		"@super-cli/signer-frontend": "workspace:*",
 		"@eth-optimism/viem": "^0.0.11",
 		"@hono/node-server": "^1.13.7",
 		"@inkjs/ui": "^2.0.0",
@@ -56,6 +55,7 @@
 		"zustand": "^5.0.1"
 	},
 	"devDependencies": {
+		"@eth-optimism/super-cli-signer-frontend": "workspace:*",
 		"@types/node": "^22.9.0",
 		"@types/react": "^18.0.32",
 		"@vdemedes/prettier-config": "^2.0.1",

--- a/packages/signer-frontend/package.json
+++ b/packages/signer-frontend/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@super-cli/signer-frontend",
+  "name": "@eth-optimism/super-cli-signer-frontend",
   "private": true,
   "version": "0.0.0",
   "type": "module",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,9 +33,6 @@ importers:
       '@libsql/client':
         specifier: ^0.14.0
         version: 0.14.0(bufferutil@4.0.8)(utf-8-validate@5.0.10)
-      '@super-cli/signer-frontend':
-        specifier: workspace:*
-        version: link:../signer-frontend
       '@tanstack/react-query':
         specifier: ^5.59.20
         version: 5.59.20(react@18.3.1)
@@ -109,6 +106,9 @@ importers:
         specifier: ^5.0.1
         version: 5.0.1(@types/react@18.3.12)(immer@10.1.1)(react@18.3.1)(use-sync-external-store@1.2.0(react@18.3.1))
     devDependencies:
+      '@eth-optimism/super-cli-signer-frontend':
+        specifier: workspace:*
+        version: link:../signer-frontend
       '@types/node':
         specifier: ^22.9.0
         version: 22.9.0


### PR DESCRIPTION
moves the signer-frontend package to dev dependency so when installing (npm i -g) it doesn't attempt to npm install (frontend package is not published as npm package yet)