### PR TITLE
nit: bridge wizard asks for recipient later

### DIFF
--- a/packages/cli/src/bridge-wizard/bridgeWizardStore.ts
+++ b/packages/cli/src/bridge-wizard/bridgeWizardStore.ts
@@ -6,14 +6,6 @@ import {zodAddress} from '@/validators/schemas';
 
 const bridgeWizard = defineWizard()
 	.addStep({
-		id: 'enter-recipient',
-		schema: z.object({
-			recipient: zodAddress,
-		}),
-		title: 'Enter Recipient',
-		getSummary: () => '',
-	})
-	.addStep({
 		id: 'select-network',
 		schema: z.object({
 			network: z.string(),
@@ -28,6 +20,14 @@ const bridgeWizard = defineWizard()
 		}),
 		title: 'Select Chains',
 		getSummary: state => `${state.chains.join(', ')}`,
+	})
+	.addStep({
+		id: 'enter-recipient',
+		schema: z.object({
+			recipient: zodAddress,
+		}),
+		title: 'Enter Recipient',
+		getSummary: () => '',
 	})
 	.addStep({
 		id: 'enter-amount',


### PR DESCRIPTION
"feels" better to add the other actions first since recipient address is a lot of work to copy and paste