### PR TITLE
feat: add prepare mode

### DIFF
--- a/packages/cli/src/actions/bridge/wizard/BridgeWizard.tsx
+++ b/packages/cli/src/actions/bridge/wizard/BridgeWizard.tsx
@@ -10,6 +10,7 @@ import {SelectNetwork} from '@/actions/bridge/wizard/steps/SelectNetwork';
 import BridgeEntrypoint from '@/commands/bridge';
 import {useSaveWizardProgress} from '@/hooks/useSaveWizardProgress';
 import {SupportedNetwork} from '@/util/fetchSuperchainRegistryChainList';
+import {toCliFlags} from '@/util/toCliFlags';
 import {Box, Text} from 'ink';
 
 type StepStatus = 'done' | 'current' | 'upcoming';
@@ -74,16 +75,8 @@ const WizardProgressForStep = ({stepId}: {stepId: BridgeWizardStepId}) => {
 };
 
 const WizardProgress = () => {
-	const {steps, wizardState} = useBridgeWizardStore();
-	if (wizardState.stepId === 'completed') {
-		const options = {
-			network: wizardState.network as SupportedNetwork,
-			chains: wizardState.chains,
-			amount: wizardState.amount,
-			recipient: wizardState.recipient,
-		};
-		return <BridgeEntrypoint options={options} />;
-	}
+	const {steps} = useBridgeWizardStore();
+
 	return (
 		<Box flexDirection="column">
 			{steps
@@ -95,7 +88,7 @@ const WizardProgress = () => {
 	);
 };
 
-export const BridgeWizard = () => {
+export const BridgeWizard = ({isPrepareMode}: {isPrepareMode?: boolean}) => {
 	const {wizardState} = useBridgeWizardStore();
 
 	// TODO: update before alpha release, remove private key step entirely from wizard
@@ -105,6 +98,28 @@ export const BridgeWizard = () => {
 	]);
 
 	const stepId = wizardState.stepId;
+
+	if (wizardState.stepId === 'completed') {
+		const options = {
+			network: wizardState.network as SupportedNetwork,
+			chains: wizardState.chains,
+			amount: wizardState.amount,
+			recipient: wizardState.recipient,
+		};
+
+		if (isPrepareMode) {
+			console.log(`sup bridge ${toCliFlags(options)}`);
+
+			// TODO: hacky way to quit until we remove pastel
+			setTimeout(() => {
+				process.exit(0);
+			}, 1);
+
+			return null;
+		}
+
+		return <BridgeEntrypoint options={options} />;
+	}
 
 	return (
 		<Box flexDirection="column" gap={1}>

--- a/packages/cli/src/actions/deploy-create2/wizard/DeployCreate2Wizard.tsx
+++ b/packages/cli/src/actions/deploy-create2/wizard/DeployCreate2Wizard.tsx
@@ -14,6 +14,7 @@ import {ShouldVerifyContract} from '@/actions/deploy-create2/wizard/steps/Should
 import {getArtifactPathForContract} from '@/util/forge/foundryProject';
 import {useSaveWizardProgress} from '@/hooks/useSaveWizardProgress';
 import {DeployCreate2Command} from '@/actions/deploy-create2/DeployCreate2Command';
+import {toCliFlags} from '@/util/toCliFlags';
 
 type StepStatus = 'done' | 'current' | 'upcoming';
 
@@ -100,7 +101,11 @@ const WizardProgress = () => {
 	);
 };
 
-export const DeployCreate2Wizard = () => {
+export const DeployCreate2Wizard = ({
+	isPrepareMode,
+}: {
+	isPrepareMode?: boolean;
+}) => {
 	const {wizardState} = useDeployCreate2WizardStore();
 
 	useSaveWizardProgress('deployCreate2', wizardState, ['completed']);
@@ -119,6 +124,17 @@ export const DeployCreate2Wizard = () => {
 			network: wizardState.network,
 			verify: wizardState.shouldVerifyContract,
 		};
+
+		if (isPrepareMode) {
+			console.log(`sup deploy create2 ${toCliFlags(options)}`);
+
+			// TODO: hacky way to quit until we remove pastel
+			setTimeout(() => {
+				process.exit(0);
+			}, 1);
+
+			return null;
+		}
 
 		return <DeployCreate2Command options={options} />;
 	}

--- a/packages/cli/src/util/toCliFlags.ts
+++ b/packages/cli/src/util/toCliFlags.ts
@@ -4,11 +4,29 @@ export const toCliFlags = (options: Record<string, any>): string => {
 			([_, value]) => value !== '' && value !== undefined && value !== null,
 		)
 		.map(([key, value]) => {
-			// Convert camelCase to kebab-case
-			const flag = key.replace(/[A-Z]/g, letter => `-${letter.toLowerCase()}`);
-			// Handle arrays by joining with commas
-			const flagValue = Array.isArray(value) ? value.join(',') : value;
-			return `--${flag} ${flagValue}`;
+			return flagToString(key, value);
 		})
-		.join(' ');
+		.join(' ')
+		.replace(/\n/g, ' ');
+};
+
+const flagToString = (key: string, value: any) => {
+	const flag = toKebabCase(key);
+
+	if (Array.isArray(value)) {
+		return `--${flag} ${value.join(',')}`;
+	}
+
+	if (typeof value === 'boolean') {
+		if (value) {
+			return `--${flag}`;
+		}
+		return '';
+	}
+
+	return `--${flag} ${value.toString().replace('\n', ' ')}`;
+};
+
+const toKebabCase = (str: string) => {
+	return str.replace(/[A-Z]/g, letter => `-${letter.toLowerCase()}`);
 };


### PR DESCRIPTION
when interactive mode is started with --prepare, it just prints the command without running it.

once we switch out the entrypoint logic from pastel to a different one, we can exit more gracefully than the hacky thing I did