### PR TITLE
feat: multi-contract deployment

### DIFF
--- a/.changeset/long-stingrays-shop.md
+++ b/.changeset/long-stingrays-shop.md
@@ -1,0 +1,5 @@
+---
+"@eth-optimism/super-cli": patch
+---
+
+added create2-many command

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -34,6 +34,7 @@
 		"@wagmi/core": "^2.16.0",
 		"abitype": "^1.0.6",
 		"chalk": "^5.3.0",
+		"dependency-graph": "^1.0.0",
 		"dotenv": "^16.4.7",
 		"drizzle-orm": "^0.38.1",
 		"fast-json-stable-stringify": "^2.1.0",

--- a/packages/cli/src/actions/deploy-create2/DeployCreate2Command.tsx
+++ b/packages/cli/src/actions/deploy-create2/DeployCreate2Command.tsx
@@ -1,29 +1,18 @@
 import {Box, Text} from 'ink';
 import {useEffect, useState} from 'react';
 
-import {Spinner, Badge} from '@inkjs/ui';
+import {Spinner} from '@inkjs/ui';
 import {DeployCreateXCreate2Params} from '@/actions/deployCreateXCreate2';
 
-import {
-	Address,
-	Chain,
-	encodeFunctionData,
-	formatEther,
-	formatUnits,
-	Hex,
-	zeroAddress,
-} from 'viem';
-import {useConfig, useWaitForTransactionReceipt} from 'wagmi';
+import {Address, Chain} from 'viem';
+import {useConfig} from 'wagmi';
 import {useForgeArtifact} from '@/queries/forgeArtifact';
 import {ForgeArtifact} from '@/util/forge/readForgeArtifact';
-import {CREATEX_ADDRESS, createXABI} from '@/util/createx/constants';
 import {useMappingChainByIdentifier} from '@/queries/chainByIdentifier';
 import {privateKeyToAccount} from 'viem/accounts';
-import {getBlockExplorerAddressLink} from '@/util/blockExplorer';
-import {getDeployCreate2Params} from '@/actions/deploy-create2/getDeployCreate2Params';
-import {useMutation, useQuery} from '@tanstack/react-query';
-import {preVerificationCheckQueryOptions} from '@/actions/deploy-create2/queries/preVerificationCheckQuery';
-import {simulationCheckQueryOptions} from '@/actions/deploy-create2/queries/simulationCheckQuery';
+import {computeDeploymentParams} from '@/actions/deploy-create2/computeDeploymentParams';
+import {useMutation} from '@tanstack/react-query';
+
 import {useChecksForChains} from '@/actions/deploy-create2/hooks/useChecksForChains';
 import {
 	ChooseExecutionOption,
@@ -31,17 +20,14 @@ import {
 } from '@/components/ChooseExecutionOption';
 
 import {VerifyCommandInner} from '@/commands/verify';
-import {useGasEstimation} from '@/hooks/useGasEstimation';
-import {useOperation} from '@/stores/operationStore';
-import {
-	deployCreate2,
-	executeTransactionOperation,
-} from '@/actions/deploy-create2/deployCreate2';
+import {deployCreate2} from '@/actions/deploy-create2/deployCreate2';
 import {
 	sendAllTransactionTasksWithPrivateKeyAccount,
 	sendAllTransactionTasksWithCustomWalletRpc,
 } from '@/actions/deploy-create2/sendAllTransactionTasks';
 import {getSponsoredSenderWalletRpcUrl} from '@/util/sponsoredSender';
+import {DeployStatus} from '@/actions/deploy-create2/components/DeployStatus';
+import {DeploymentParams} from '@/actions/deploy-create2/types';
 
 // Prepares any required data or loading state if waiting
 export const DeployCreate2Command = ({
@@ -76,22 +62,32 @@ export const DeployCreate2Command = ({
 		return chain;
 	});
 
+	const intent = {
+		chains,
+		forgeArtifactPath: options.forgeArtifactPath,
+		forgeArtifact,
+		constructorArgs: options.constructorArgs?.split(','),
+		salt: options.salt,
+	};
+
+	const computedParams = computeDeploymentParams(intent);
+
 	return (
 		<DeployCreate2CommandInner
-			chains={chains}
-			forgeArtifact={forgeArtifact}
+			deploymentParams={{
+				intent,
+				computedParams,
+			}}
 			options={options}
 		/>
 	);
 };
 
 const DeployCreate2CommandInner = ({
-	chains,
-	forgeArtifact,
+	deploymentParams,
 	options,
 }: {
-	chains: Chain[];
-	forgeArtifact: ForgeArtifact;
+	deploymentParams: DeploymentParams;
 	options: DeployCreateXCreate2Params;
 }) => {
 	const [executionOption, setExecutionOption] =
@@ -101,18 +97,10 @@ const DeployCreate2CommandInner = ({
 				: null,
 		);
 
-	const {initCode, deterministicAddress, baseSalt} = getDeployCreate2Params({
-		forgeArtifact,
-		constructorArgs: options.constructorArgs,
-		salt: options.salt,
-	});
+	const {initCode, deterministicAddress, baseSalt} =
+		deploymentParams.computedParams;
 
-	const {chainsToDeployTo: chainIdsToDeployTo} = useChecksForChains({
-		deterministicAddress,
-		initCode,
-		baseSalt,
-		chainIds: chains.map(chain => chain.id),
-	});
+	const {chainIdsToDeployTo} = useChecksForChains(deploymentParams);
 
 	const wagmiConfig = useConfig();
 
@@ -164,7 +152,9 @@ const DeployCreate2CommandInner = ({
 					<Text>
 						Target Chains:{' '}
 						<Text color="green">
-							{chains.map(chain => chain.name).join(', ')}
+							{deploymentParams.intent.chains
+								.map(chain => chain.name)
+								.join(', ')}
 						</Text>
 					</Text>
 					<Text>
@@ -192,14 +182,14 @@ const DeployCreate2CommandInner = ({
 			<Box flexDirection="column" paddingX={2}>
 				<Box flexDirection="row">
 					<Box flexDirection="column" marginRight={2}>
-						{chains.map(chain => (
+						{deploymentParams.intent.chains.map(chain => (
 							<Text key={chain.id} bold color="blue">
 								{chain.name}:
 							</Text>
 						))}
 					</Box>
 					<Box flexDirection="column">
-						{chains.map(chain => (
+						{deploymentParams.intent.chains.map(chain => (
 							<DeployStatus
 								key={chain.id}
 								chain={chain}
@@ -240,10 +230,10 @@ const DeployCreate2CommandInner = ({
 			{data && (
 				<CompletedOrVerify
 					shouldVerify={!!options.verify}
-					chains={chains}
+					chains={deploymentParams.intent.chains}
 					forgeArtifactPath={options.forgeArtifactPath}
 					contractAddress={deterministicAddress}
-					forgeArtifact={forgeArtifact}
+					forgeArtifact={deploymentParams.intent.forgeArtifact}
 				/>
 			)}
 		</Box>
@@ -282,279 +272,5 @@ const CompletedOrVerify = ({
 			contractAddress={contractAddress}
 			forgeArtifact={forgeArtifact}
 		/>
-	);
-};
-
-const DeployStatus = ({
-	chain,
-	initCode,
-	baseSalt,
-	deterministicAddress,
-	executionOption,
-}: {
-	chain: Chain;
-	initCode: Hex;
-	baseSalt: Hex;
-	deterministicAddress: Address;
-	executionOption: ExecutionOption | null;
-}) => {
-	const wagmiConfig = useConfig();
-
-	const {
-		data: preVerificationCheckData,
-		isLoading: isPreVerificationCheckLoading,
-		error: preVerificationCheckError,
-	} = useQuery({
-		...preVerificationCheckQueryOptions(wagmiConfig, {
-			deterministicAddress,
-			initCode,
-			baseSalt,
-			chainId: chain.id,
-		}),
-	});
-
-	const {
-		data: simulationData,
-		isLoading: isSimulationLoading,
-		error: simulationError,
-	} = useQuery({
-		...simulationCheckQueryOptions(wagmiConfig, {
-			deterministicAddress,
-			initCode,
-			baseSalt,
-			chainId: chain.id,
-		}),
-	});
-
-	const {data: gasEstimation, isLoading: isGasEstimationLoading} =
-		useGasEstimation({
-			chainId: chain.id,
-			to: CREATEX_ADDRESS,
-			account: zeroAddress,
-
-			data: encodeFunctionData({
-				abi: createXABI,
-				functionName: 'deployCreate2',
-				args: [baseSalt, initCode],
-			}),
-		});
-
-	if (preVerificationCheckError) {
-		return (
-			<Box gap={1}>
-				<Badge color="red">Error</Badge>
-				<Text>
-					Pre-verification check failed:{' '}
-					{preVerificationCheckError.message.split('\n')[0]}
-				</Text>
-			</Box>
-		);
-	}
-
-	if (isPreVerificationCheckLoading || !preVerificationCheckData) {
-		return <Spinner label="Checking if contract is already deployed" />;
-	}
-
-	if (preVerificationCheckData.isAlreadyDeployed) {
-		return (
-			<Box gap={1}>
-				<Badge color="green">Deployed</Badge>
-				<Text>Contract is already deployed</Text>
-
-				<Text>{getBlockExplorerAddressLink(chain, deterministicAddress)}</Text>
-			</Box>
-		);
-	}
-
-	if (simulationError) {
-		return (
-			<Box gap={1}>
-				<Badge color="red">Error</Badge>
-				<Text>
-					Simulation check failed: {simulationError.message.split('\n')[0]}
-				</Text>
-			</Box>
-		);
-	}
-
-	if (isSimulationLoading || !simulationData) {
-		return (
-			<Spinner label="Simulating deployment to check for address mismatch" />
-		);
-	}
-
-	if (!simulationData.isAddressSameAsExpected) {
-		return (
-			<Box gap={1}>
-				<Badge color="red">Failed</Badge>
-				<Text>Address mismatch</Text>
-			</Box>
-		);
-	}
-
-	if (!executionOption) {
-		return (
-			<Box gap={1}>
-				<Badge color="blue">Ready</Badge>
-				<Text>Estimated fees</Text>
-				{isGasEstimationLoading || !gasEstimation ? (
-					<Spinner />
-				) : (
-					<GasEstimation gasEstimation={gasEstimation} />
-				)}
-			</Box>
-		);
-	}
-
-	if (
-		executionOption.type === 'privateKey' ||
-		executionOption.type === 'sponsoredSender'
-	) {
-		return (
-			<PrivateKeyExecution
-				chain={chain}
-				initCode={initCode}
-				baseSalt={baseSalt}
-				deterministicAddress={deterministicAddress}
-			/>
-		);
-	}
-
-	return (
-		<ExternalSignerExecution
-			chain={chain}
-			initCode={initCode}
-			baseSalt={baseSalt}
-			deterministicAddress={deterministicAddress}
-		/>
-	);
-};
-
-const GasEstimation = ({
-	gasEstimation,
-}: {
-	gasEstimation: {
-		totalFee: bigint;
-		estimatedL1Fee: bigint;
-		estimatedL2Gas: bigint;
-		l2GasPrice: bigint;
-	};
-}) => {
-	return (
-		<Text>
-			<Text>(L1 Fee: </Text>
-			<Text color="green">{formatEther(gasEstimation.estimatedL1Fee)} ETH</Text>
-			<Text>) + (L2 Gas: </Text>
-			<Text color="yellow">{gasEstimation.estimatedL2Gas.toString()}</Text>
-			<Text> gas × L2 Gas Price: </Text>
-			<Text color="cyan">{formatUnits(gasEstimation.l2GasPrice, 9)} gwei</Text>
-			<Text>) = </Text>
-			<Text color="green" bold>
-				{formatEther(gasEstimation.totalFee)} ETH
-			</Text>
-		</Text>
-	);
-};
-
-const PrivateKeyExecution = ({
-	chain,
-	initCode,
-	baseSalt,
-	deterministicAddress,
-}: {
-	chain: Chain;
-	initCode: Hex;
-	baseSalt: Hex;
-	deterministicAddress: Address;
-}) => {
-	const {
-		status,
-		data: transactionHash,
-		error,
-	} = useOperation(
-		executeTransactionOperation({
-			chainId: chain.id,
-			deterministicAddress,
-			initCode,
-			baseSalt,
-		}),
-	);
-
-	const {isLoading: isReceiptLoading} = useWaitForTransactionReceipt({
-		hash: transactionHash,
-		chainId: chain.id,
-	});
-
-	if (status === 'pending') {
-		return <Spinner label="Deploying contract" />;
-	}
-
-	if (error) {
-		return <Text>Error deploying contract: {error.message}</Text>;
-	}
-
-	if (isReceiptLoading) {
-		return <Spinner label="Waiting for receipt" />;
-	}
-
-	return (
-		<Box gap={1}>
-			<Badge color="green">Deployed</Badge>
-			<Text>Contract successfully deployed</Text>
-			<Text>{getBlockExplorerAddressLink(chain, deterministicAddress)}</Text>
-		</Box>
-	);
-};
-
-const ExternalSignerExecution = ({
-	chain,
-	initCode,
-	baseSalt,
-	deterministicAddress,
-}: {
-	chain: Chain;
-	initCode: Hex;
-	baseSalt: Hex;
-	deterministicAddress: Address;
-}) => {
-	const {data: hash} = useOperation(
-		executeTransactionOperation({
-			chainId: chain.id,
-			deterministicAddress,
-			initCode,
-			baseSalt,
-		}),
-	);
-
-	const {data: receipt, isLoading: isReceiptLoading} =
-		useWaitForTransactionReceipt({
-			hash,
-			chainId: chain.id,
-		});
-
-	if (!hash) {
-		return (
-			<Box gap={1}>
-				<Spinner label="Waiting for signature..." />
-				<Box flexDirection="row">
-					<Text>Send the transaction at </Text>
-					<Text color="cyan" bold>
-						http://localhost:3000
-					</Text>
-				</Box>
-			</Box>
-		);
-	}
-
-	if (isReceiptLoading || !receipt) {
-		return <Spinner label="Waiting for receipt" />;
-	}
-
-	return (
-		<Box gap={1}>
-			<Badge color="green">Deployed</Badge>
-			<Text>Contract successfully deployed</Text>
-			<Text>{getBlockExplorerAddressLink(chain, deterministicAddress)}</Text>
-		</Box>
 	);
 };

--- a/packages/cli/src/actions/deploy-create2/components/DeployStatus.tsx
+++ b/packages/cli/src/actions/deploy-create2/components/DeployStatus.tsx
@@ -1,0 +1,168 @@
+import {preVerificationCheckQueryOptions} from '@/actions/deploy-create2/queries/preVerificationCheckQuery';
+import {simulationCheckQueryOptions} from '@/actions/deploy-create2/queries/simulationCheckQuery';
+import {ExecutionOption} from '@/components/ChooseExecutionOption';
+import {useGasEstimation} from '@/hooks/useGasEstimation';
+import {CREATEX_ADDRESS, createXABI} from '@/util/createx/constants';
+import {useQuery} from '@tanstack/react-query';
+import {Badge, Spinner} from '@inkjs/ui';
+import {Text, Box} from 'ink';
+import {Address, Chain, encodeFunctionData, Hex, zeroAddress} from 'viem';
+import {useConfig} from 'wagmi';
+import {getBlockExplorerAddressLink} from '@/util/blockExplorer';
+import {PrivateKeyExecution} from '@/actions/deploy-create2/components/PrivateKeyExecution';
+import {ExternalSignerExecution} from '@/actions/deploy-create2/components/ExternalSignerExecution';
+import {GasEstimation} from '@/actions/deploy-create2/components/GasEstimation';
+import {supersimL1} from '@eth-optimism/viem/chains';
+import {privateKeyToAccount} from 'viem/accounts';
+
+export const DeployStatus = ({
+	chain,
+	initCode,
+	baseSalt,
+	deterministicAddress,
+	executionOption,
+}: {
+	chain: Chain;
+	initCode: Hex;
+	baseSalt: Hex;
+	deterministicAddress: Address;
+	executionOption: ExecutionOption | null;
+}) => {
+	const wagmiConfig = useConfig();
+
+	const {
+		data: preVerificationCheckData,
+		isLoading: isPreVerificationCheckLoading,
+		error: preVerificationCheckError,
+	} = useQuery({
+		...preVerificationCheckQueryOptions(wagmiConfig, {
+			deterministicAddress,
+			initCode,
+			baseSalt,
+			chainId: chain.id,
+		}),
+	});
+
+	const {
+		data: simulationData,
+		isLoading: isSimulationLoading,
+		error: simulationError,
+	} = useQuery({
+		...simulationCheckQueryOptions(wagmiConfig, {
+			deterministicAddress,
+			initCode,
+			baseSalt,
+			chainId: chain.id,
+		}),
+	});
+
+	const {data: gasEstimation, isLoading: isGasEstimationLoading} =
+		useGasEstimation({
+			chainId: chain.id,
+			to: CREATEX_ADDRESS,
+			account:
+				// TODO: fix - hacky way to get the account for the chain
+				chain.sourceId === supersimL1.id
+					? privateKeyToAccount(
+							'0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80',
+					  )
+					: executionOption?.type === 'privateKey'
+					? privateKeyToAccount(executionOption.privateKey)
+					: zeroAddress,
+			data: encodeFunctionData({
+				abi: createXABI,
+				functionName: 'deployCreate2',
+				args: [baseSalt, initCode],
+			}),
+		});
+
+	if (preVerificationCheckError) {
+		return (
+			<Box gap={1}>
+				<Badge color="red">Error</Badge>
+				<Text>
+					Pre-verification check failed:{' '}
+					{preVerificationCheckError.message.split('\n')[0]}
+				</Text>
+			</Box>
+		);
+	}
+
+	if (isPreVerificationCheckLoading || !preVerificationCheckData) {
+		return <Spinner label="Checking if contract is already deployed" />;
+	}
+
+	if (preVerificationCheckData.isAlreadyDeployed) {
+		return (
+			<Box gap={1}>
+				<Badge color="green">Deployed</Badge>
+				<Text>Contract is already deployed</Text>
+
+				<Text>{getBlockExplorerAddressLink(chain, deterministicAddress)}</Text>
+			</Box>
+		);
+	}
+
+	if (simulationError) {
+		return (
+			<Box gap={1}>
+				<Badge color="red">Error</Badge>
+				<Text>
+					Simulation check failed: {simulationError.message.split('\n')[0]}
+				</Text>
+			</Box>
+		);
+	}
+
+	if (isSimulationLoading || !simulationData) {
+		return (
+			<Spinner label="Simulating deployment to check for address mismatch" />
+		);
+	}
+
+	if (!simulationData.isAddressSameAsExpected) {
+		return (
+			<Box gap={1}>
+				<Badge color="red">Failed</Badge>
+				<Text>Address mismatch</Text>
+			</Box>
+		);
+	}
+
+	if (!executionOption) {
+		return (
+			<Box gap={1}>
+				<Badge color="blue">Ready</Badge>
+				<Text>Estimated fees</Text>
+				{isGasEstimationLoading || !gasEstimation ? (
+					<Spinner />
+				) : (
+					<GasEstimation gasEstimation={gasEstimation} />
+				)}
+			</Box>
+		);
+	}
+
+	if (
+		executionOption.type === 'privateKey' ||
+		executionOption.type === 'sponsoredSender'
+	) {
+		return (
+			<PrivateKeyExecution
+				chain={chain}
+				initCode={initCode}
+				baseSalt={baseSalt}
+				deterministicAddress={deterministicAddress}
+			/>
+		);
+	}
+
+	return (
+		<ExternalSignerExecution
+			chain={chain}
+			initCode={initCode}
+			baseSalt={baseSalt}
+			deterministicAddress={deterministicAddress}
+		/>
+	);
+};

--- a/packages/cli/src/actions/deploy-create2/components/ExternalSignerExecution.tsx
+++ b/packages/cli/src/actions/deploy-create2/components/ExternalSignerExecution.tsx
@@ -1,0 +1,60 @@
+import {executeTransactionOperation} from '@/actions/deploy-create2/deployCreate2';
+import {useOperation} from '@/stores/operationStore';
+import {Address, Chain, Hex} from 'viem';
+import {useWaitForTransactionReceipt} from 'wagmi';
+import {Spinner, Badge} from '@inkjs/ui';
+import {Text, Box} from 'ink';
+import {getBlockExplorerAddressLink} from '@/util/blockExplorer';
+
+export const ExternalSignerExecution = ({
+	chain,
+	initCode,
+	baseSalt,
+	deterministicAddress,
+}: {
+	chain: Chain;
+	initCode: Hex;
+	baseSalt: Hex;
+	deterministicAddress: Address;
+}) => {
+	const {data: hash} = useOperation(
+		executeTransactionOperation({
+			chainId: chain.id,
+			deterministicAddress,
+			initCode,
+			baseSalt,
+		}),
+	);
+
+	const {data: receipt, isLoading: isReceiptLoading} =
+		useWaitForTransactionReceipt({
+			hash,
+			chainId: chain.id,
+		});
+
+	if (!hash) {
+		return (
+			<Box gap={1}>
+				<Spinner label="Waiting for signature..." />
+				<Box flexDirection="row">
+					<Text>Send the transaction at </Text>
+					<Text color="cyan" bold>
+						http://localhost:3000
+					</Text>
+				</Box>
+			</Box>
+		);
+	}
+
+	if (isReceiptLoading || !receipt) {
+		return <Spinner label="Waiting for receipt" />;
+	}
+
+	return (
+		<Box gap={1}>
+			<Badge color="green">Deployed</Badge>
+			<Text>Contract successfully deployed</Text>
+			<Text>{getBlockExplorerAddressLink(chain, deterministicAddress)}</Text>
+		</Box>
+	);
+};

--- a/packages/cli/src/actions/deploy-create2/components/GasEstimation.tsx
+++ b/packages/cli/src/actions/deploy-create2/components/GasEstimation.tsx
@@ -1,0 +1,28 @@
+import {formatEther, formatUnits} from 'viem';
+import {Text} from 'ink';
+
+export const GasEstimation = ({
+	gasEstimation,
+}: {
+	gasEstimation: {
+		totalFee: bigint;
+		estimatedL1Fee: bigint;
+		estimatedL2Gas: bigint;
+		l2GasPrice: bigint;
+	};
+}) => {
+	return (
+		<Text>
+			<Text>(L1 Fee: </Text>
+			<Text color="green">{formatEther(gasEstimation.estimatedL1Fee)} ETH</Text>
+			<Text>) + (L2 Gas: </Text>
+			<Text color="yellow">{gasEstimation.estimatedL2Gas.toString()}</Text>
+			<Text> gas × L2 Gas Price: </Text>
+			<Text color="cyan">{formatUnits(gasEstimation.l2GasPrice, 9)} gwei</Text>
+			<Text>) = </Text>
+			<Text color="green" bold>
+				{formatEther(gasEstimation.totalFee)} ETH
+			</Text>
+		</Text>
+	);
+};

--- a/packages/cli/src/actions/deploy-create2/components/PrivateKeyExecution.tsx
+++ b/packages/cli/src/actions/deploy-create2/components/PrivateKeyExecution.tsx
@@ -1,0 +1,57 @@
+import {executeTransactionOperation} from '@/actions/deploy-create2/deployCreate2';
+import {useOperation} from '@/stores/operationStore';
+import {Spinner, Badge} from '@inkjs/ui';
+import {Address, Chain, Hex} from 'viem';
+import {useWaitForTransactionReceipt} from 'wagmi';
+import {getBlockExplorerAddressLink} from '@/util/blockExplorer';
+import {Text, Box} from 'ink';
+
+export const PrivateKeyExecution = ({
+	chain,
+	initCode,
+	baseSalt,
+	deterministicAddress,
+}: {
+	chain: Chain;
+	initCode: Hex;
+	baseSalt: Hex;
+	deterministicAddress: Address;
+}) => {
+	const {
+		status,
+		data: transactionHash,
+		error,
+	} = useOperation(
+		executeTransactionOperation({
+			chainId: chain.id,
+			deterministicAddress,
+			initCode,
+			baseSalt,
+		}),
+	);
+
+	const {isLoading: isReceiptLoading} = useWaitForTransactionReceipt({
+		hash: transactionHash,
+		chainId: chain.id,
+	});
+
+	if (status === 'pending') {
+		return <Spinner label="Deploying contract" />;
+	}
+
+	if (error) {
+		return <Text>Error deploying contract: {error.message}</Text>;
+	}
+
+	if (isReceiptLoading) {
+		return <Spinner label="Waiting for receipt" />;
+	}
+
+	return (
+		<Box gap={1}>
+			<Badge color="green">Deployed</Badge>
+			<Text>Contract successfully deployed</Text>
+			<Text>{getBlockExplorerAddressLink(chain, deterministicAddress)}</Text>
+		</Box>
+	);
+};

--- a/packages/cli/src/actions/deploy-create2/computeDeploymentParams.ts
+++ b/packages/cli/src/actions/deploy-create2/computeDeploymentParams.ts
@@ -1,19 +1,21 @@
 import {computeCreate2Address} from '@/util/createx/computeCreate2Address';
 import {createBaseSalt, createGuardedSalt} from '@/util/createx/salt';
-import {ForgeArtifact} from '@/util/forge/readForgeArtifact';
 import {getEncodedConstructorArgs} from '@/util/abi';
 import {concatHex, keccak256, toHex} from 'viem';
+import {
+	ComputedDeploymentParams,
+	DeploymentIntent,
+} from '@/actions/deploy-create2/types';
 
 // Prepares params for deployCreate2
-export const getDeployCreate2Params = ({
+export const computeDeploymentParams = ({
 	forgeArtifact,
 	constructorArgs,
 	salt,
-}: {
-	forgeArtifact: ForgeArtifact;
-	constructorArgs?: string;
-	salt: string;
-}) => {
+}: Pick<
+	DeploymentIntent,
+	'forgeArtifact' | 'constructorArgs' | 'salt'
+>): ComputedDeploymentParams => {
 	const baseSalt = createBaseSalt({
 		shouldAddRedeployProtection: false,
 		additionalEntropy: toHex(salt, {size: 32}),
@@ -25,7 +27,7 @@ export const getDeployCreate2Params = ({
 
 	const encodedConstructorArgs = getEncodedConstructorArgs(
 		forgeArtifact.abi,
-		constructorArgs?.split(','),
+		constructorArgs,
 	);
 
 	const initCode = encodedConstructorArgs

--- a/packages/cli/src/actions/deploy-create2/hooks/useChecksForChainsForContracts.ts
+++ b/packages/cli/src/actions/deploy-create2/hooks/useChecksForChainsForContracts.ts
@@ -1,0 +1,88 @@
+import {Address} from 'viem';
+import {useConfig} from 'wagmi';
+
+import {useQueries} from '@tanstack/react-query';
+import {preVerificationCheckQueryOptions} from '@/actions/deploy-create2/queries/preVerificationCheckQuery';
+import {simulationCheckQueryOptions} from '@/actions/deploy-create2/queries/simulationCheckQuery';
+import {DeploymentParams} from '@/actions/deploy-create2/types';
+
+export const useChecksForChainsForContracts = (
+	deployments: DeploymentParams[],
+) => {
+	const wagmiConfig = useConfig();
+
+	const flattenedDeployments = deployments.flatMap(deployment => {
+		return deployment.intent.chains.map(chain => ({
+			...deployment,
+			chain,
+		}));
+	});
+
+	const preVerificationCheckQueries = useQueries({
+		queries: flattenedDeployments.map(({chain, computedParams}) => ({
+			...preVerificationCheckQueryOptions(wagmiConfig, {
+				deterministicAddress: computedParams.deterministicAddress,
+				initCode: computedParams.initCode,
+				baseSalt: computedParams.baseSalt,
+				chainId: chain.id,
+			}),
+		})),
+	});
+
+	const simulationQueries = useQueries({
+		queries: flattenedDeployments.map(({chain, computedParams}) => ({
+			...simulationCheckQueryOptions(wagmiConfig, {
+				deterministicAddress: computedParams.deterministicAddress,
+				initCode: computedParams.initCode,
+				baseSalt: computedParams.baseSalt,
+				chainId: chain.id,
+			}),
+		})),
+	});
+
+	const isSimulationCompleted = simulationQueries.every(
+		query => query.isSuccess,
+	);
+
+	const isPreVerificationCheckCompleted = preVerificationCheckQueries.every(
+		query => query.isSuccess,
+	);
+
+	if (isSimulationCompleted && isPreVerificationCheckCompleted) {
+		const shouldDeployArr = flattenedDeployments.map((_, i) => {
+			return (
+				!preVerificationCheckQueries[i]!.data!.isAlreadyDeployed &&
+				simulationQueries[i]!.data!.isAddressSameAsExpected
+			);
+		});
+
+		const chainIdSetByAddress = deployments.reduce<
+			Record<Address, Set<number>>
+		>((acc, deployment, deploymentIndex) => {
+			acc[deployment.computedParams.deterministicAddress] = new Set(
+				deployment.intent.chains
+					.filter((_, chainIndex) => {
+						const queryIndex =
+							deploymentIndex * deployment.intent.chains.length + chainIndex;
+						return shouldDeployArr[queryIndex]!;
+					})
+					.map(chain => chain.id),
+			);
+			return acc;
+		}, {});
+
+		return {
+			isSimulationCompleted,
+			isPreVerificationCheckCompleted,
+			chainIdSetByAddress,
+			hasDeployableChains: shouldDeployArr.some(shouldDeploy => shouldDeploy),
+		};
+	}
+
+	return {
+		isSimulationCompleted,
+		isPreVerificationCheckCompleted,
+		chainIdSetByAddress: undefined,
+		hasDeployableChains: undefined,
+	};
+};

--- a/packages/cli/src/actions/deploy-create2/queries/preVerificationCheckQuery.ts
+++ b/packages/cli/src/actions/deploy-create2/queries/preVerificationCheckQuery.ts
@@ -2,6 +2,7 @@ import {Address, Hex} from 'viem';
 import {Config} from 'wagmi';
 
 import {getBytecode} from '@wagmi/core';
+import {ComputedDeploymentParams} from '@/actions/deploy-create2/types';
 
 export const preVerificationCheckQueryKey = (
 	deterministicAddress: Address,
@@ -25,10 +26,7 @@ export const preVerificationCheckQueryOptions = (
 		initCode,
 		baseSalt,
 		chainId,
-	}: {
-		deterministicAddress: Address;
-		initCode: Hex;
-		baseSalt: Hex;
+	}: ComputedDeploymentParams & {
 		chainId: number;
 	},
 ) => {

--- a/packages/cli/src/actions/deploy-create2/queries/simulationCheckQuery.ts
+++ b/packages/cli/src/actions/deploy-create2/queries/simulationCheckQuery.ts
@@ -11,6 +11,7 @@ import {Config} from 'wagmi';
 import {simulateContract} from '@wagmi/core';
 import {CREATEX_ADDRESS, createXABI} from '@/util/createx/constants';
 import {supersimNetwork} from '@/util/chains/networks';
+import {ComputedDeploymentParams} from '@/actions/deploy-create2/types';
 
 // Heuristics for funded accounts on chains
 const getFundedAccountForChain = (chainId: number) => {
@@ -38,10 +39,7 @@ export const simulationCheckQueryOptions = (
 		initCode,
 		baseSalt,
 		chainId,
-	}: {
-		deterministicAddress: Address;
-		initCode: Hex;
-		baseSalt: Hex;
+	}: ComputedDeploymentParams & {
 		chainId: number;
 	},
 ) => {

--- a/packages/cli/src/actions/deploy-create2/types.ts
+++ b/packages/cli/src/actions/deploy-create2/types.ts
@@ -1,0 +1,21 @@
+import {ForgeArtifact} from '@/util/forge/readForgeArtifact';
+import {Address, Chain, Hex} from 'viem';
+
+export type DeploymentIntent = {
+	chains: Chain[];
+	forgeArtifactPath: string;
+	forgeArtifact: ForgeArtifact;
+	constructorArgs?: any[];
+	salt: string;
+};
+
+export type ComputedDeploymentParams = {
+	deterministicAddress: Address;
+	initCode: Hex;
+	baseSalt: Hex;
+};
+
+export type DeploymentParams = {
+	intent: DeploymentIntent;
+	computedParams: ComputedDeploymentParams;
+};

--- a/packages/cli/src/commands/deploy/create2-many.tsx
+++ b/packages/cli/src/commands/deploy/create2-many.tsx
@@ -1,0 +1,453 @@
+import {Spinner, StatusMessage} from '@inkjs/ui';
+import {z} from 'zod';
+import {option} from 'pastel';
+import fs from 'fs/promises';
+import {parse as parseTOML} from 'smol-toml';
+
+import {zodSupportedNetwork} from '@/util/fetchSuperchainRegistryChainList';
+import {useQueries} from '@tanstack/react-query';
+import {getForgeArtifactQueryParams} from '@/queries/forgeArtifact';
+import {
+	resolveContractDeploymentParams,
+	UnresolvedConstructorArg,
+	UnresolvedContractDeploymentParams,
+	zodTarget,
+} from '@/util/resolveContractDeploymentParams';
+
+import {Box, Text} from 'ink';
+import {useEffect, useState} from 'react';
+
+import {Address} from 'viem';
+import {useConfig} from 'wagmi';
+import {ForgeArtifact} from '@/util/forge/readForgeArtifact';
+import {useMappingChainByIdentifier} from '@/queries/chainByIdentifier';
+import {privateKeyToAccount} from 'viem/accounts';
+import {computeDeploymentParams} from '@/actions/deploy-create2/computeDeploymentParams';
+import {useMutation, useQuery} from '@tanstack/react-query';
+
+import {
+	ChooseExecutionOption,
+	ExecutionOption,
+} from '@/components/ChooseExecutionOption';
+
+import {VerifyCommandInner} from '@/commands/verify';
+
+import {deployCreate2} from '@/actions/deploy-create2/deployCreate2';
+import {
+	sendAllTransactionTasksWithPrivateKeyAccount,
+	sendAllTransactionTasksWithCustomWalletRpc,
+} from '@/actions/deploy-create2/sendAllTransactionTasks';
+import {getSponsoredSenderWalletRpcUrl} from '@/util/sponsoredSender';
+import {zodPrivateKey} from '@/util/schemas';
+import {useChecksForChainsForContracts} from '@/actions/deploy-create2/hooks/useChecksForChainsForContracts';
+import {DeployStatus} from '@/actions/deploy-create2/components/DeployStatus';
+import {DeploymentParams} from '@/actions/deploy-create2/types';
+
+const zodContractConfig = z
+	.object({
+		id: z.string().optional(),
+		salt: z.string(),
+		constructor_args: z.array(z.any()).optional(),
+		forge_artifact_path: z.string(),
+	})
+	.transform(params => {
+		return {
+			id: params.id,
+			salt: params.salt,
+			constructorArgs: params.constructor_args,
+			forgeArtifactPath: params.forge_artifact_path,
+		};
+	});
+
+export type ContractConfig = z.infer<typeof zodContractConfig>;
+
+const zodCreate2ManyConfig = z.object({
+	chains: z.array(z.string()),
+	network: zodSupportedNetwork,
+	contracts: z.array(zodContractConfig),
+});
+
+const zodDeployCreate2ManyCommandOptions = z.object({
+	toml: z.string().describe(
+		option({
+			description: 'Path to a TOML file to use as a configuration',
+			alias: 't',
+		}),
+	),
+	privateKey: zodPrivateKey.optional().describe(
+		option({
+			description: 'Signer private key',
+			alias: 'pk',
+		}),
+	),
+	verify: z
+		.boolean()
+		.optional()
+		.describe(
+			option({
+				description: 'Verify contracts after deployment',
+				alias: 'v',
+			}),
+		),
+});
+
+const toUnresolvedConstructorArg = (arg: any): UnresolvedConstructorArg => {
+	// handle {{TokenERC20.address}} or {{TokenERC20.someOtherProp}}
+	// => { type: 'reference', id: 'TokenERC20', target: 'address' | 'someOtherProp' }
+	if (typeof arg === 'string') {
+		const match = arg.match(/^{{([^.]+)\.([^}]+)}}$/);
+		if (match) {
+			if (match.length !== 3) {
+				throw new Error('Invalid reference format');
+			}
+
+			const target = zodTarget.safeParse(match[2]);
+			if (target.success === false) {
+				throw new Error('Invalid target');
+			}
+
+			return {
+				type: 'reference',
+				id: match[1]!,
+				target: target.data,
+			};
+		}
+	}
+
+	return {type: 'value', value: arg};
+};
+
+const toUnresolvedContractDeploymentParams = (
+	config: ContractConfig,
+	forgeArtifact: ForgeArtifact,
+): UnresolvedContractDeploymentParams => {
+	return {
+		id: config.id || config.forgeArtifactPath, // default to the forge artifact path if no id is provided
+		salt: config.salt,
+		constructorArgs: config.constructorArgs?.map(toUnresolvedConstructorArg),
+		forgeArtifact,
+	};
+};
+
+const DeployCreate2ManyCommand = ({
+	options,
+}: {
+	options: z.infer<typeof zodDeployCreate2ManyCommandOptions>;
+}) => {
+	const {
+		data: config,
+		isLoading: isConfigLoading,
+		error,
+	} = useQuery({
+		queryKey: ['read-toml', options.toml],
+		queryFn: async () => {
+			const raw = await fs.readFile(options.toml, {encoding: 'utf-8'});
+
+			const parsedToml = parseTOML(raw);
+
+			const parsed = zodCreate2ManyConfig.safeParse(parsedToml);
+
+			if (parsed.success === false) {
+				throw new Error('Invalid config file');
+			}
+
+			return parsed.data;
+		},
+	});
+
+	if (isConfigLoading) {
+		return <Spinner />;
+	}
+
+	if (error) {
+		return <StatusMessage variant="error">{error.message}</StatusMessage>;
+	}
+
+	if (!config) {
+		return <StatusMessage variant="error">No config found</StatusMessage>;
+	}
+
+	return <DeployCreate2ManyWithConfig config={config} options={options} />;
+};
+
+// TODO: Make this wayyy simpler or split out into multiple components
+const DeployCreate2ManyWithConfig = ({
+	config,
+	options,
+}: {
+	config: z.infer<typeof zodCreate2ManyConfig>;
+	options: z.infer<typeof zodDeployCreate2ManyCommandOptions>;
+}) => {
+	const forgeArtifactQueryResults = useQueries({
+		queries: config.contracts.map(contract =>
+			getForgeArtifactQueryParams(contract.forgeArtifactPath),
+		),
+	});
+
+	const {data: chainByIdentifier, isLoading: isChainByIdentifierLoading} =
+		useMappingChainByIdentifier();
+
+	if (isChainByIdentifierLoading || !chainByIdentifier) {
+		return <Spinner label="Loading chain configurations..." />;
+	}
+
+	if (forgeArtifactQueryResults.some(result => result.isLoading)) {
+		return <Spinner label="Loading forge artifacts..." />;
+	}
+
+	if (forgeArtifactQueryResults.some(result => result.error)) {
+		return (
+			<StatusMessage variant="error">
+				{forgeArtifactQueryResults.find(result => result.error)?.error?.message}
+			</StatusMessage>
+		);
+	}
+
+	if (forgeArtifactQueryResults.some(result => result.data === undefined)) {
+		return (
+			<StatusMessage variant="error">
+				Error loading forge artifacts
+			</StatusMessage>
+		);
+	}
+
+	const unresolvedContractDeploymentParams = forgeArtifactQueryResults.map(
+		(result, index) =>
+			toUnresolvedContractDeploymentParams(
+				config.contracts[index]!,
+				result.data!,
+			),
+	);
+
+	const resolvedContractDeploymentParams = resolveContractDeploymentParams(
+		unresolvedContractDeploymentParams,
+	);
+
+	const flattenedChains = config.chains.flatMap(chain => chain.split(','));
+	const chains = flattenedChains.map(x => {
+		const chain = chainByIdentifier[`${config.network}/${x}`]!;
+		if (!chain) {
+			throw new Error(`Chain ${`${config.network}/${x}`} not found`);
+		}
+		return chain;
+	});
+
+	const deploymentParams = config.contracts.map((contract, index) => {
+		const {forgeArtifact, constructorArgs, salt} =
+			resolvedContractDeploymentParams[index]!;
+
+		const intent = {
+			chains,
+			forgeArtifactPath: contract.forgeArtifactPath,
+			forgeArtifact,
+			constructorArgs,
+			salt,
+		};
+
+		return {
+			intent,
+			computedParams: computeDeploymentParams(intent),
+		};
+	});
+
+	return (
+		<DeployCreate2ManyCommandInner
+			deploymentParams={deploymentParams}
+			options={options}
+		/>
+	);
+};
+
+const DeployCreate2ManyCommandInner = ({
+	deploymentParams,
+	options,
+}: {
+	deploymentParams: DeploymentParams[];
+	options: z.infer<typeof zodDeployCreate2ManyCommandOptions>;
+}) => {
+	const [executionOption, setExecutionOption] =
+		useState<ExecutionOption | null>(
+			options.privateKey
+				? {type: 'privateKey', privateKey: options.privateKey}
+				: null,
+		);
+
+	const {chainIdSetByAddress, hasDeployableChains} =
+		useChecksForChainsForContracts(deploymentParams);
+	const wagmiConfig = useConfig();
+
+	const {mutate, data} = useMutation({
+		mutationFn: () => {
+			if (!chainIdSetByAddress) {
+				throw new Error('No chains to deploy to');
+			}
+
+			return Promise.all(
+				deploymentParams.map(async ({intent, computedParams}) => {
+					const {forgeArtifactPath, constructorArgs, chains} = intent;
+					const {deterministicAddress, initCode, baseSalt} = computedParams;
+					const chainIdsToDeployTo = chainIdSetByAddress[deterministicAddress]!;
+
+					if (chainIdsToDeployTo.size === 0) {
+						return;
+					}
+
+					return await deployCreate2({
+						wagmiConfig,
+						deterministicAddress,
+						initCode,
+						baseSalt,
+						chains: chains.filter(chain => chainIdsToDeployTo.has(chain.id)),
+						foundryArtifactPath: forgeArtifactPath,
+						contractArguments: constructorArgs || [],
+						account: options.privateKey
+							? privateKeyToAccount(options.privateKey)
+							: undefined,
+					});
+				}),
+			);
+		},
+	});
+
+	useEffect(() => {
+		if (!chainIdSetByAddress) return;
+		mutate();
+	}, [
+		Object.keys(chainIdSetByAddress || {})
+			.map(key => {
+				return Array.from(
+					(chainIdSetByAddress?.[key as Address] || []).values(),
+				).join(',');
+			})
+			.join(','),
+	]);
+
+	return (
+		<Box flexDirection="column" gap={1}>
+			{deploymentParams.map(({intent, computedParams}, i) => (
+				<Box flexDirection="column" gap={1} key={intent.forgeArtifactPath}>
+					<Box flexDirection="column" gap={1}>
+						<Text bold>
+							Deploy {i + 1}:{' '}
+							<Text color="cyan">{intent.forgeArtifactPath}</Text>
+						</Text>
+
+						<Box flexDirection="column" paddingLeft={2}>
+							<Text></Text>
+							<Text>
+								Salt: <Text color="magenta">{intent.salt}</Text>
+							</Text>
+
+							{intent.constructorArgs && (
+								<Box flexDirection="column">
+									<Text>Constructor Arguments:</Text>
+									<Text color="cyan">{intent.constructorArgs?.join(', ')}</Text>
+								</Box>
+							)}
+							<Box>
+								<Text>
+									Address:{' '}
+									<Text color="yellow" bold>
+										{computedParams.deterministicAddress}
+									</Text>
+								</Text>
+							</Box>
+						</Box>
+					</Box>
+					<Box flexDirection="column" paddingX={2}>
+						<Box flexDirection="row">
+							<Box flexDirection="column" marginRight={2}>
+								{intent.chains.map(chain => (
+									<Text key={chain.id} bold color="blue">
+										{chain.name}:
+									</Text>
+								))}
+							</Box>
+							<Box flexDirection="column">
+								{intent.chains.map(chain => (
+									<DeployStatus
+										key={chain.id}
+										chain={chain}
+										initCode={computedParams.initCode}
+										baseSalt={computedParams.baseSalt}
+										deterministicAddress={computedParams.deterministicAddress}
+										executionOption={executionOption}
+									/>
+								))}
+							</Box>
+						</Box>
+					</Box>
+				</Box>
+			))}
+			{hasDeployableChains && !executionOption && (
+				<Box>
+					<ChooseExecutionOption
+						label={'🚀 Ready to deploy!'}
+						onSubmit={async executionOption => {
+							if (executionOption.type === 'privateKey') {
+								setExecutionOption(executionOption);
+								await sendAllTransactionTasksWithPrivateKeyAccount(
+									privateKeyToAccount(executionOption.privateKey),
+								);
+							} else if (executionOption.type === 'sponsoredSender') {
+								setExecutionOption(executionOption);
+								await sendAllTransactionTasksWithCustomWalletRpc(chainId =>
+									getSponsoredSenderWalletRpcUrl(
+										executionOption.apiKey,
+										chainId,
+									),
+								);
+							} else {
+								setExecutionOption(executionOption);
+							}
+						}}
+					/>
+				</Box>
+			)}
+			{data && (
+				<CompletedOrVerify
+					shouldVerify={!!options.verify}
+					deploymentParams={deploymentParams}
+				/>
+			)}
+		</Box>
+	);
+};
+
+const CompletedOrVerify = ({
+	shouldVerify,
+	deploymentParams,
+}: {
+	shouldVerify: boolean;
+	deploymentParams: DeploymentParams[];
+}) => {
+	if (!shouldVerify) {
+		// TODO: hacky way to quit until we remove pastel
+		setTimeout(() => {
+			process.exit(0);
+		}, 1);
+		return (
+			<Box>
+				<Text>Contracts are successfully deployed to all chains</Text>
+			</Box>
+		);
+	}
+
+	return (
+		<Box flexDirection="column" gap={1}>
+			{deploymentParams.map((deploymentParam, index) => (
+				<VerifyCommandInner
+					key={deploymentParam.computedParams.deterministicAddress}
+					chains={deploymentParam.intent.chains}
+					forgeArtifactPath={deploymentParam.intent.forgeArtifactPath}
+					contractAddress={deploymentParam.computedParams.deterministicAddress}
+					forgeArtifact={deploymentParam.intent.forgeArtifact}
+					index={index}
+				/>
+			))}
+		</Box>
+	);
+};
+
+export default DeployCreate2ManyCommand;
+export const options = zodDeployCreate2ManyCommandOptions;

--- a/packages/cli/src/commands/verify.tsx
+++ b/packages/cli/src/commands/verify.tsx
@@ -60,11 +60,13 @@ export const VerifyCommandInner = ({
 	forgeArtifactPath,
 	contractAddress,
 	forgeArtifact,
+	index,
 }: {
 	chains: Chain[];
 	forgeArtifactPath: string;
 	contractAddress: Address;
 	forgeArtifact: ForgeArtifact;
+	index?: number;
 }) => {
 	const {data: standardJsonInput, isLoading: isStandardJsonInputLoading} =
 		useStandardJsonInputQuery(forgeArtifactPath);
@@ -89,8 +91,9 @@ export const VerifyCommandInner = ({
 	return (
 		<Box flexDirection="column">
 			<Box marginBottom={1}>
-				<Text bold underline>
-					Contract Verification (Blockscout)
+				<Text bold>
+					Verify{index !== undefined ? ` ${index + 1}` : ''}:{' '}
+					<Text color="cyan">{forgeArtifactPath}</Text>
 				</Text>
 			</Box>
 			<Box flexDirection="row" paddingLeft={2}>

--- a/packages/cli/src/hooks/useGasEstimation.ts
+++ b/packages/cli/src/hooks/useGasEstimation.ts
@@ -1,5 +1,5 @@
 import {useQuery} from '@tanstack/react-query';
-import {Address, Hex} from 'viem';
+import {Account, Address, Hex} from 'viem';
 import {estimateL1Fee} from 'viem/op-stack';
 import {useEstimateGas, usePublicClient, useGasPrice} from 'wagmi';
 
@@ -11,7 +11,7 @@ export const useGasEstimation = ({
 }: {
 	to: Address;
 	data: Hex;
-	account: Address;
+	account: Account | Address;
 	chainId: number;
 }) => {
 	const publicClient = usePublicClient({
@@ -63,7 +63,10 @@ export const useGasEstimation = ({
 		l2GasPriceError ||
 		undefined;
 
-	const areValuesAvailable = estimatedL1Fee && estimatedL2Gas && l2GasPrice;
+	const areValuesAvailable =
+		estimatedL1Fee !== undefined &&
+		estimatedL2Gas !== undefined &&
+		l2GasPrice !== undefined;
 
 	if (isLoading || !areValuesAvailable) {
 		return {

--- a/packages/cli/src/util/forge/readForgeArtifact.ts
+++ b/packages/cli/src/util/forge/readForgeArtifact.ts
@@ -9,7 +9,7 @@ const zodCompilerOutputSource = z.object({
 	license: z.string(),
 });
 
-const zodForgeArtifact = z.object({
+export const zodForgeArtifact = z.object({
 	abi: Abi,
 	bytecode: z.object({
 		object: zodHex,

--- a/packages/cli/src/util/resolveContractDeploymentParams.ts
+++ b/packages/cli/src/util/resolveContractDeploymentParams.ts
@@ -1,0 +1,160 @@
+import {computeDeploymentParams} from '@/actions/deploy-create2/computeDeploymentParams';
+import {zodForgeArtifact} from '@/util/forge/readForgeArtifact';
+import {zodAddress} from '@/util/schemas';
+import {DepGraph, DepGraphCycleError} from 'dependency-graph';
+import z from 'zod';
+
+export const zodDerivedParams = z.object({
+	address: zodAddress,
+});
+
+export const zodTarget = zodDerivedParams.keyof();
+
+export const zodConstructorArgReference = z.object({
+	type: z.literal('reference'),
+	id: z.string(),
+	target: zodTarget,
+});
+
+export type DerivedParams = z.infer<typeof zodDerivedParams>;
+
+const zodConstructorArg = z.any();
+
+export const zodConstructorArgValue = z.object({
+	type: z.literal('value'),
+	value: zodConstructorArg,
+});
+
+export const zodUnresolvedConstructorArg = z.discriminatedUnion('type', [
+	zodConstructorArgReference,
+	zodConstructorArgValue,
+]);
+
+export type UnresolvedConstructorArg = z.infer<
+	typeof zodUnresolvedConstructorArg
+>;
+
+export const zodUnresolvedContractDeploymentParams = z.object({
+	id: z.string(),
+	salt: z.string(),
+	constructorArgs: z.array(zodUnresolvedConstructorArg).optional(),
+	forgeArtifact: zodForgeArtifact,
+});
+
+export const zodResolvedContractDeploymentParams = z.object({
+	id: z.string(),
+	salt: z.string(),
+	constructorArgs: z.array(zodConstructorArg).optional(),
+	forgeArtifact: zodForgeArtifact,
+});
+
+export type UnresolvedContractDeploymentParams = z.infer<
+	typeof zodUnresolvedContractDeploymentParams
+>;
+
+export type ResolvedContractDeploymentParams = z.infer<
+	typeof zodResolvedContractDeploymentParams
+>;
+
+const getDerivedParams = (
+	resolvedParams: ResolvedContractDeploymentParams,
+): DerivedParams => {
+	const {salt, constructorArgs, forgeArtifact} = resolvedParams;
+
+	const {deterministicAddress} = computeDeploymentParams({
+		forgeArtifact,
+		constructorArgs,
+		salt,
+	});
+
+	return {
+		address: deterministicAddress,
+	};
+};
+
+const resolveForContract = (
+	params: UnresolvedContractDeploymentParams,
+	accumulatedParamsById: Record<string, DerivedParams>,
+): ResolvedContractDeploymentParams => {
+	const {id, salt, constructorArgs, forgeArtifact} = params;
+
+	const resolvedConstructorArgs = constructorArgs?.map(arg => {
+		if (arg.type === 'reference') {
+			const value = accumulatedParamsById[arg.id]?.[arg.target];
+			if (!value) {
+				throw new Error(`Reference to ${arg.id} not found`);
+			}
+
+			return value;
+		}
+
+		return arg.value;
+	});
+
+	const resolvedParams = {
+		id,
+		salt,
+		constructorArgs: resolvedConstructorArgs,
+		forgeArtifact,
+	};
+
+	return resolvedParams;
+};
+
+export const resolveContractDeploymentParams = (
+	params: UnresolvedContractDeploymentParams[],
+): ResolvedContractDeploymentParams[] => {
+	const graph = new DepGraph<UnresolvedContractDeploymentParams>();
+
+	params.forEach(param => {
+		graph.addNode(param.id, param);
+	});
+
+	params.forEach(({id, constructorArgs}) => {
+		constructorArgs?.forEach(arg => {
+			if (arg.type === 'reference') {
+				graph.addDependency(id, arg.id);
+			}
+		});
+	});
+
+	let order: string[];
+	try {
+		order = graph.overallOrder();
+	} catch (e) {
+		if (e instanceof DepGraphCycleError) {
+			// TODO: bubble this to user
+			console.error(e.cyclePath);
+			throw new Error('Failed to create deployment plan');
+		}
+
+		throw e;
+	}
+
+	const result = order.reduce<{
+		derivedParamsById: Record<string, DerivedParams>;
+		resolvedParamsById: Record<string, ResolvedContractDeploymentParams>;
+	}>(
+		(acc, id) => {
+			const unresolvedParams = graph.getNodeData(id);
+			const resolvedParams = resolveForContract(
+				unresolvedParams,
+				acc.derivedParamsById,
+			);
+
+			return {
+				derivedParamsById: {
+					...acc.derivedParamsById,
+					[id]: getDerivedParams(resolvedParams),
+				},
+				resolvedParamsById: {
+					...acc.resolvedParamsById,
+					[id]: resolvedParams,
+				},
+			};
+		},
+		{derivedParamsById: {}, resolvedParamsById: {}},
+	);
+
+	return params.map(param => result.resolvedParamsById[param.id]!);
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       chalk:
         specifier: ^5.3.0
         version: 5.3.0
+      dependency-graph:
+        specifier: ^1.0.0
+        version: 1.0.0
       dotenv:
         specifier: ^16.4.7
         version: 16.4.7
@@ -2784,6 +2787,10 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
 
+  dependency-graph@1.0.0:
+    resolution: {integrity: sha512-cW3gggJ28HZ/LExwxP2B++aiKxhJXMSIt9K48FOXQkm+vuG5gyatXnLsONRJdzO/7VfjDIiaOOa/bs4l464Lwg==}
+    engines: {node: '>=4'}
+
   destr@2.0.3:
     resolution: {integrity: sha512-2N3BOUU4gYMpTP24s5rF5iP7BDr7uNTCs4ozw3kf/eKfvWSIu93GEBi5m427YoyJoeOzQ5smuu4nNAPGb8idSQ==}
 
@@ -3917,6 +3924,7 @@ packages:
 
   libsql@0.4.7:
     resolution: {integrity: sha512-T9eIRCs6b0J1SHKYIvD8+KCJMcWZ900iZyxdnSCdqxN12Z1ijzT+jY5nrk72Jw4B0HGzms2NgpryArlJqvc3Lw==}
+    cpu: [x64, arm64, wasm32]
     os: [darwin, linux, win32]
 
   lilconfig@3.1.3:
@@ -8240,6 +8248,8 @@ snapshots:
   defu@6.1.4: {}
 
   delayed-stream@1.0.0: {}
+
+  dependency-graph@1.0.0: {}
 
   destr@2.0.3: {}
 


### PR DESCRIPTION
Allows using symbols to specify multiple contracts in a toml. under `sup deploy create2`. uses `dep-graph` to figure out dependency graph of contracts

<img width="1082" alt="image" src="https://github.com/user-attachments/assets/41befb7a-33f1-49ec-aaab-8a566cfa11fd" />

```toml

chains = ["interop-alpha-0", "interop-alpha-1"]
network = "interop-alpha"

[[contracts]]
id = "FlashLoanVault"
salt = "ethers"
forge_artifact_path = "/Users/james/oplabs/superchain-starter-xchain-flash-loan-example/contracts/out/FlashLoanVault.sol/FlashLoanVault.json"

[[contracts]]
id = "CrosschainFlashLoanToken"
salt = "ethers"
forge_artifact_path = "/Users/james/oplabs/superchain-starter-xchain-flash-loan-example/contracts/out/CrosschainFlashLoanToken.sol/CrosschainFlashLoanToken.json"

[[contracts]]
id = "CrosschainFlashLoanBridge"
salt = "ethers"
forge_artifact_path = "/Users/james/oplabs/superchain-starter-xchain-flash-loan-example/contracts/out/CrosschainFlashLoanBridge.sol/CrosschainFlashLoanBridge.json"
constructor_args = [
  "{{CrosschainFlashLoanToken.address}}",
  "{{FlashLoanVault.address}}",
  "10000000000000000",
  "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266",
]

[[contracts]]
id = "TargetContract"
salt = "ethers"
forge_artifact_path = "/Users/james/oplabs/superchain-starter-xchain-flash-loan-example/contracts/out/TargetContract.sol/TargetContract.json"

```

also cleaned up the shared types between create2 and create2many

TODO: better fail state when cycle found