### PR TITLE
feat: add tx-sender class and fix private key deployments causing replacement tx

### DIFF
--- a/.changeset/tough-squids-breathe.md
+++ b/.changeset/tough-squids-breathe.md
@@ -1,0 +1,5 @@
+---
+"@eth-optimism/super-cli": patch
+---
+
+fixed private key deployments causing replacement tx

--- a/packages/cli/src/actions/deploy-create2/DeployCreate2Command.tsx
+++ b/packages/cli/src/actions/deploy-create2/DeployCreate2Command.tsx
@@ -28,6 +28,7 @@ import {
 import {getSponsoredSenderWalletRpcUrl} from '@/util/sponsoredSender';
 import {DeployStatus} from '@/actions/deploy-create2/components/DeployStatus';
 import {DeploymentParams} from '@/actions/deploy-create2/types';
+import {createTxSenderFromPrivateKeyAccount} from '@/util/TxSender';
 
 // Prepares any required data or loading state if waiting
 export const DeployCreate2Command = ({
@@ -116,6 +117,13 @@ const DeployCreate2CommandInner = ({
 				throw new Error('No chains to deploy to');
 			}
 
+			const txSender = options.privateKey
+				? createTxSenderFromPrivateKeyAccount(
+						wagmiConfig,
+						privateKeyToAccount(options.privateKey),
+				  )
+				: undefined;
+
 			return deployCreate2({
 				wagmiConfig,
 				deterministicAddress,
@@ -124,9 +132,7 @@ const DeployCreate2CommandInner = ({
 				chains: chainsToDeployTo,
 				foundryArtifactPath: options.forgeArtifactPath,
 				contractArguments: options.constructorArgs?.split(',') ?? [],
-				account: options.privateKey
-					? privateKeyToAccount(options.privateKey)
-					: undefined,
+				txSender,
 			});
 		},
 	});

--- a/packages/cli/src/actions/deploy-create2/components/PrivateKeyExecution.tsx
+++ b/packages/cli/src/actions/deploy-create2/components/PrivateKeyExecution.tsx
@@ -40,7 +40,12 @@ export const PrivateKeyExecution = ({
 	}
 
 	if (error) {
-		return <Text>Error deploying contract: {error.message}</Text>;
+		return (
+			<Text>
+				{/* @ts-expect-error */}
+				Error deploying contract: {error.shortMessage || error.message}
+			</Text>
+		);
 	}
 
 	if (isReceiptLoading) {

--- a/packages/cli/src/actions/deploy-create2/sendAllTransactionTasks.ts
+++ b/packages/cli/src/actions/deploy-create2/sendAllTransactionTasks.ts
@@ -4,9 +4,21 @@ import {
 	useTransactionTaskStore,
 } from '@/stores/transactionTaskStore';
 import {chainById} from '@/util/chains/chains';
+import {TxSender} from '@/util/TxSender';
 import {http, sendTransaction} from '@wagmi/core';
 import {createWalletClient, zeroAddress} from 'viem';
 import {PrivateKeyAccount} from 'viem/accounts';
+
+export const sendAllTransactionTasks = async (txSender: TxSender) => {
+	const taskEntryById = useTransactionTaskStore.getState().taskEntryById;
+
+	await Promise.all(
+		Object.values(taskEntryById).map(async task => {
+			const hash = await txSender.sendTx(task.request);
+			onTaskSuccess(task.id, hash);
+		}),
+	);
+};
 
 export const sendAllTransactionTasksWithPrivateKeyAccount = async (
 	account: PrivateKeyAccount,

--- a/packages/cli/src/util/AsyncQueue.ts
+++ b/packages/cli/src/util/AsyncQueue.ts
@@ -1,0 +1,48 @@
+export interface AsyncQueueItem<T, R> {
+	item: T;
+	resolve: (value: R) => void;
+	reject: (error: any) => void;
+}
+
+// Simple queue that processes items sequentially
+export class AsyncQueue<T, R> {
+	private queue: AsyncQueueItem<T, R>[] = [];
+	private processing = false;
+	private processFn: (item: T) => Promise<R>;
+
+	constructor(processFn: (item: T) => Promise<R>) {
+		this.processFn = processFn;
+	}
+
+	public enqueue(item: T): Promise<R> {
+		return new Promise((resolve, reject) => {
+			this.queue.push({item, resolve, reject});
+			this.processQueue();
+		});
+	}
+
+	private async processQueue(): Promise<void> {
+		if (this.processing) {
+			return;
+		}
+		this.processing = true;
+
+		try {
+			while (this.queue.length > 0) {
+				const queueItem = this.queue.shift();
+				if (!queueItem) continue;
+				try {
+					const result = await this.processFn(queueItem.item);
+					queueItem.resolve(result);
+				} catch (error) {
+					queueItem.reject(error);
+				}
+			}
+		} finally {
+			this.processing = false;
+			if (this.queue.length > 0) {
+				this.processQueue();
+			}
+		}
+	}
+}

--- a/packages/cli/src/util/TxSender.ts
+++ b/packages/cli/src/util/TxSender.ts
@@ -1,0 +1,77 @@
+import {AsyncQueue} from '@/util/AsyncQueue';
+import {chainById} from '@/util/chains/chains';
+import {TransactionTask} from '@/util/transactionTask';
+import {sendTransaction, waitForTransactionReceipt} from '@wagmi/core';
+import {
+	createWalletClient,
+	Hash,
+	http,
+	PrivateKeyAccount,
+	zeroAddress,
+} from 'viem';
+import {Config} from 'wagmi';
+
+type WalletRpcUrlFactory = (chainId: number) => string;
+
+type TxSenderTx = TransactionTask;
+
+export interface TxSender {
+	sendTx: (tx: TxSenderTx) => Promise<Hash>;
+}
+
+export const createTxSenderFromPrivateKeyAccount = (
+	config: Config,
+	account: PrivateKeyAccount,
+): TxSender => {
+	const queueByChainId = {} as Record<number, AsyncQueue<TxSenderTx, Hash>>;
+
+	config.chains.forEach(chain => {
+		queueByChainId[chain.id] = new AsyncQueue<TxSenderTx, Hash>(async tx => {
+			const hash = await sendTransaction(config, {
+				chainId: tx.chainId,
+				to: tx.to,
+				data: tx.data,
+				account,
+			});
+			// Prevent replacement tx.
+			await waitForTransactionReceipt(config, {
+				hash,
+				chainId: tx.chainId,
+				pollingInterval: 1000,
+			});
+
+			return hash;
+		});
+	});
+
+	return {
+		sendTx: async tx => {
+			if (!queueByChainId[tx.chainId]) {
+				throw new Error(`Chain tx queue for ${tx.chainId} not found`);
+			}
+			return await queueByChainId[tx.chainId]!.enqueue(tx);
+		},
+	};
+};
+
+export const createTxSenderFromCustomWalletRpc = (
+	getRpcUrl: WalletRpcUrlFactory,
+): TxSender => {
+	return {
+		sendTx: async tx => {
+			const chain = chainById[tx.chainId];
+			if (!chain) {
+				throw new Error(`Chain not found for ${tx.chainId}`);
+			}
+			const walletClient = createWalletClient({
+				transport: http(getRpcUrl(tx.chainId)),
+			});
+			return await walletClient.sendTransaction({
+				to: tx.to,
+				data: tx.data,
+				account: zeroAddress, // will be ignored
+				chain: chain,
+			});
+		},
+	};
+};


### PR DESCRIPTION
Adds TxSender and AsyncQueue. For private key deployments, the tx per chain should always be run sequentially.