### PR TITLE
fix: show error when cycle detected & misc fixes

### DIFF
--- a/.changeset/fluffy-windows-kneel.md
+++ b/.changeset/fluffy-windows-kneel.md
@@ -1,0 +1,5 @@
+---
+"@eth-optimism/super-cli": patch
+---
+
+error out when cycle is detected, suggest foundry project path, --prepare mode handles string quotations

--- a/packages/cli/src/actions/deploy-create2/wizard/DeployCreate2Wizard.tsx
+++ b/packages/cli/src/actions/deploy-create2/wizard/DeployCreate2Wizard.tsx
@@ -16,6 +16,7 @@ import {useSaveWizardProgress} from '@/hooks/useSaveWizardProgress';
 import {DeployCreate2Command} from '@/actions/deploy-create2/DeployCreate2Command';
 import {toCliFlags} from '@/util/toCliFlags';
 import {BackNavigation} from '@/components/navigation/BackNavigation';
+import path from 'path';
 
 type StepStatus = 'done' | 'current' | 'upcoming';
 
@@ -124,10 +125,13 @@ export const DeployCreate2Wizard = ({
 	if (stepId === 'completed') {
 		const options = {
 			chains: wizardState.chainNames,
-			salt: wizardState.salt,
-			forgeArtifactPath: getArtifactPathForContract(
-				wizardState.foundryProjectPath,
-				wizardState.selectedContract,
+			salt: `"${wizardState.salt}"`,
+			forgeArtifactPath: path.relative(
+				process.cwd(),
+				getArtifactPathForContract(
+					wizardState.foundryProjectPath,
+					wizardState.selectedContract,
+				),
 			),
 			constructorArgs: wizardState.constructorArgs.join(','),
 			network: wizardState.network,

--- a/packages/cli/src/commands/deploy/create2-many.tsx
+++ b/packages/cli/src/commands/deploy/create2-many.tsx
@@ -9,6 +9,7 @@ import {useQueries} from '@tanstack/react-query';
 import {getForgeArtifactQueryParams} from '@/queries/forgeArtifact';
 import {
 	resolveContractDeploymentParams,
+	ResolvedContractDeploymentParams,
 	UnresolvedConstructorArg,
 	UnresolvedContractDeploymentParams,
 	zodTarget,
@@ -221,9 +222,18 @@ const DeployCreate2ManyWithConfig = ({
 			),
 	);
 
-	const resolvedContractDeploymentParams = resolveContractDeploymentParams(
-		unresolvedContractDeploymentParams,
-	);
+	// TODO: remove this try/catch inside a render fn
+	let resolvedContractDeploymentParams: ResolvedContractDeploymentParams[];
+	try {
+		resolvedContractDeploymentParams = resolveContractDeploymentParams(
+			unresolvedContractDeploymentParams,
+		);
+	} catch (e) {
+		if (e instanceof Error) {
+			return <StatusMessage variant="error">{e.message}</StatusMessage>;
+		}
+		throw e;
+	}
 
 	const flattenedChains = config.chains.flatMap(chain => chain.split(','));
 	const chains = flattenedChains.map(x => {

--- a/packages/cli/src/components/path-input/PathInput.tsx
+++ b/packages/cli/src/components/path-input/PathInput.tsx
@@ -51,7 +51,6 @@ interface PathInputProps {
 
 export function PathInput({defaultValue = '', onSubmit}: PathInputProps) {
 	const [suggestions, setSuggestions] = useState<string[]>([]);
-	const [submittedPath, setSubmittedPath] = useState<string | null>(null);
 	const [error, setError] = useState<string | null>(null);
 
 	const lastValueRef = useRef<string>('');
@@ -67,7 +66,6 @@ export function PathInput({defaultValue = '', onSubmit}: PathInputProps) {
 				return;
 			}
 			setError(null);
-			setSubmittedPath(resolvedPath);
 			onSubmit?.(resolvedPath);
 		},
 		[onSubmit],
@@ -241,13 +239,6 @@ export function PathInput({defaultValue = '', onSubmit}: PathInputProps) {
 			{error && (
 				<Box marginTop={1}>
 					<Text color="red">✗ {error}</Text>
-				</Box>
-			)}
-
-			{submittedPath && !error && (
-				<Box marginTop={1}>
-					<Text color="green">✓ Directory selected: </Text>
-					<Text>{submittedPath}</Text>
 				</Box>
 			)}
 

--- a/packages/cli/src/util/resolveContractDeploymentParams.ts
+++ b/packages/cli/src/util/resolveContractDeploymentParams.ts
@@ -123,9 +123,11 @@ export const resolveContractDeploymentParams = (
 		order = graph.overallOrder();
 	} catch (e) {
 		if (e instanceof DepGraphCycleError) {
-			// TODO: bubble this to user
-			console.error(e.cyclePath);
-			throw new Error('Failed to create deployment plan');
+			throw new Error(
+				`Failed to create deployment plan, cycle detected ${e.cyclePath.join(
+					' -> ',
+				)}`,
+			);
 		}
 
 		throw e;


### PR DESCRIPTION
- error out when cycle is detected between contracts
- suggest a contracts path when none is found
- --prepare mode spits out relative path, and handles quotation marks for salt strings