### PR TITLE
Fix issues with docker installations and uniform using mise

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,9 @@
 version: 2.1
 
 orbs:
+  utils: ethereum-optimism/circleci-utils@1.0.17
   nx: nrwl/nx@1.6.2
-  node: circleci/node@6.3.0
-  utils: ethereum-optimism/circleci-utils@1.0.16
+
 
 
 commands:
@@ -25,21 +25,20 @@ commands:
           command: pnpm release:version:snapshot
 
   setup:
-    description: "Setup"
+    description: "Setup Node.js environment with pnpm and nx"
     steps:
-      - checkout
-      - node/install-pnpm:
-          version: '9'
+      - utils/checkout-with-mise      # Install dependencies
       - run:
-          name: Install pnpm dependencies
-          command: pnpm install --frozen-lockfile
+          name: Install dependencies
           environment:
             NPM_TOKEN: nada
+          command: |
+            pnpm i --frozen-lockfile
 
 jobs:
   publish-to-npm:
-    docker:
-      - image: cimg/node:20.11
+    machine:
+      image: ubuntu-2204:2024.08.1
     parameters:
       prepare-snapshot:
         type: boolean
@@ -82,9 +81,8 @@ jobs:
 
 
   check:
-    executor:
-      name: node/default
-      tag: '22.10'
+    machine:
+      image: ubuntu-2204:2024.08.1
     steps:
       - setup
       - nx/set-shas

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,10 @@
+[tools]
+node = "18.18.0"
+
+[hooks]
+# Enabling corepack will install the `pnpm` package manager specified in package.json
+postinstall = "npx corepack enable"
+
+[settings]
+# Needs to be enabled for hooks to work
+experimental = true


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

We have issue with installing global package in docker.
We uniform this repository with other similar one where we do not need to deal with different version of docker.

<img width="936" alt="Screenshot 2025-03-12 at 17 27 24" src="https://github.com/user-attachments/assets/eb6df4b5-e486-404a-a78e-ce0235599e19" />


This pull request includes several updates to the CircleCI configuration and the addition of a new `mise.toml` file to manage tools and settings. The most important changes are as follows:

### CircleCI Configuration Updates:

* Updated the `utils` orb to version `1.0.17` and removed the `node` orb from `.circleci/config.yml`.
* Modified the `setup` command to include a more descriptive name and changed the steps to use `utils/checkout-with-mise` for dependency installation.
* Changed the `publish-to-npm` and `check` jobs to use a machine executor with the `ubuntu-2204:2024.08.1` image instead of a Docker executor.

### Tool and Setting Management:

* Added a new `mise.toml` file to specify the Node.js version, enable corepack for `pnpm`, and configure experimental settings.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
