### PR TITLE
add jobs depdencies and add script for release:version:snapshot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,7 +129,7 @@ workflows:
               - circleci-repo-super-cli # for GITHUB_TOKEN_GOVERNANCE && NPM_TOKEN
           requires:
             - check
-            - publish-to-npm
+            - "Publish new versions"  # Changed from 'publish-to-npm' to the actual job name
           filters:
             branches:
               only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -129,6 +129,7 @@ workflows:
               - circleci-repo-super-cli # for GITHUB_TOKEN_GOVERNANCE && NPM_TOKEN
           requires:
             - check
+            - publish-to-npm
           filters:
             branches:
               only: main

--- a/package.json
+++ b/package.json
@@ -6,8 +6,7 @@
    "scripts": {
       "release:publish": "changeset publish",
       "release:version": "changeset version && pnpm install --lockfile-only",
-		"release:version:snapshot": "changeset version --snapshot ${SNAPSHOT_NAME:-snapshot} && pnpm install --lockfile-only"
-
+      "release:version:snapshot": "changeset version --snapshot ${SNAPSHOT_NAME:-snapshot} && pnpm install --lockfile-only"
    },
    "dependencies": {
       "@changesets/cli": "^2.27.10",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
    "nx": {},
    "scripts": {
       "release:publish": "changeset publish",
-      "release:version": "changeset version && pnpm install --lockfile-only"
+      "release:version": "changeset version && pnpm install --lockfile-only",
+		"release:version:snapshot": "changeset version --snapshot ${SNAPSHOT_NAME:-snapshot} && pnpm install --lockfile-only"
+
    },
    "dependencies": {
       "@changesets/cli": "^2.27.10",


### PR DESCRIPTION
<!--
Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**

<!--
A clear and concise description of the features you're adding in this pull request.
-->

This pull request includes updates to the CI/CD pipeline and introduces a new script for handling snapshot versions in the `package.json` file.

Changes to CI/CD pipeline:

* [`.circleci/config.yml`](diffhunk://#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47R132): Added a new step `publish-to-npm` to the `requires` section under `workflows`.

Updates to `package.json`:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L8-R10): Added a new script `release:version:snapshot` to handle snapshot versions using `changeset`.

**Tests**

<!--
Please describe any tests you've added. If you've added no tests, or left important behavior untested, please explain why not.
-->

**Additional context**

<!--
Add any other context about the problem you're solving.
-->

**Metadata**

<!-- 
Include a link to any github issues that this may close in the following form:
- Fixes #[Link to Issue]
-->
